### PR TITLE
avviser hvis fnr mangler eller ikke stemmer med signatur

### DIFF
--- a/src/main/kotlin/no/nav/syfo/apprec/ApprecMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/apprec/ApprecMapper.kt
@@ -65,8 +65,8 @@ fun createApprec(fellesformat: XMLEIFellesformat, apprecStatus: ApprecStatus): X
 
 fun XMLHealthcareProfessional.intoHCPerson(): XMLHCPerson = XMLHCPerson().apply {
     name = if (middleName == null) "$familyName $givenName" else "$familyName $givenName $middleName"
-    id = ident.first().id
-    typeId = ident.first().typeId.intoCS()
+    id = ident.firstOrNull()?.id
+    typeId = ident.firstOrNull()?.typeId?.intoCS()
     additionalId += ident.drop(1)
 }
 

--- a/src/main/kotlin/no/nav/syfo/model/LegeerklaringMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/model/LegeerklaringMapper.kt
@@ -201,8 +201,13 @@ operator fun Iterable<AktueltTiltak>.contains(typeTiltak: TypeTiltak) =
 operator fun Iterable<no.nav.helse.legeerklaering.Kontakt>.contains(kontaktType: KontaktType): Boolean =
         any { it.kontakt.toInt() == kontaktType.type }
 
-fun XMLHealthcareProfessional.formatName(): String = if (middleName == null) {
-        "${familyName.toUpperCase()} ${givenName.toUpperCase()}"
-} else {
-        "${familyName.toUpperCase()} ${givenName.toUpperCase()} ${middleName.toUpperCase()}"
+fun XMLHealthcareProfessional.formatName(): String? {
+        if (familyName.isNullOrEmpty() && givenName.isNullOrEmpty()) {
+                return null
+        }
+        return if (middleName == null) {
+                "${familyName?.toUpperCase()} ${givenName?.toUpperCase()}"
+        } else {
+                "${familyName?.toUpperCase()} ${givenName?.toUpperCase()} ${middleName.toUpperCase()}"
+        }
 }

--- a/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
@@ -20,6 +20,11 @@ fun extractOrganisationRashNumberFromSender(fellesformat: XMLEIFellesformat): XM
         it.typeId.v == "RSH"
     }
 
+fun extractAvsenderFnrFromSender(fellesformat: XMLEIFellesformat): XMLIdent? =
+    fellesformat.get<XMLMsgHead>().msgInfo.sender.organisation.healthcareProfessional.ident.find {
+        it.typeId.v == "FNR"
+    }
+
 fun extractLegeerklaering(fellesformat: XMLEIFellesformat): Legeerklaring =
     fellesformat.get<XMLMsgHead>().document[0].refDoc.content.any[0] as Legeerklaring
 


### PR DESCRIPTION
FNR er en påkrevd del av healthcareprofessional (avsenderinfo), og vi kan dermed avvise legeerklæringer der dette mangler. Vi ønsker også å avvise legeerklæringer der avsender ikke er den samme som den som har signert legeerklæringen. 

Jeg har også rettet den feilen der vi prøver å formattere navn som ikke er satt :)