### PR TITLE
Retain incoming timestamp

### DIFF
--- a/src/main/kotlin/no/nav/syfo/BlockingApplicationRunner.kt
+++ b/src/main/kotlin/no/nav/syfo/BlockingApplicationRunner.kt
@@ -65,6 +65,7 @@ import no.nav.syfo.util.wrapExceptions
 import no.nav.syfo.vedlegg.google.BucketUploadService
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.xml.sax.InputSource
+import java.time.ZoneId
 
 class BlockingApplicationRunner(
     private val applicationState: ApplicationState,
@@ -161,7 +162,7 @@ class BlockingApplicationRunner(
                         receiverBlock.mottattDatotid
                             .toGregorianCalendar()
                             .toZonedDateTime()
-                            .withZoneSameInstant(ZoneOffset.UTC)
+                            .withZoneSameInstant(ZoneId.of("Europe/Oslo"))
                             .toLocalDateTime()
 
                     val duplicateCheck =


### PR DESCRIPTION
Vi ser at tidsstempelet forskyver seg 2 timer (så i et tilfelle får innkommende legeerklæring innkommende tidsstempel *før* tidspunktet veileder har sendt forespørsel om legeerklæring).